### PR TITLE
Update _modal.sass

### DIFF
--- a/src/modal/_modal.sass
+++ b/src/modal/_modal.sass
@@ -45,6 +45,7 @@ $modal-z-index: 2000 !default
   line-height: $modal-button-height
   opacity: 0.8
   overflow: hidden
+  padding: 0
   position: absolute
   right: 3.69853vw
   text-align: center


### PR DESCRIPTION
Fixes an issue on certain legacy iOS Safari with `<button>`.